### PR TITLE
Add Stackdriver Micrometer support

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -75,6 +75,12 @@
         <version>${micrometer.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-stackdriver</artifactId>
+        <version>${micrometer.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-stackdriver</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/deployment/src/main/java/dev/ebullient/micrometer/deployment/MicrometerDotNames.java
+++ b/deployment/src/main/java/dev/ebullient/micrometer/deployment/MicrometerDotNames.java
@@ -20,6 +20,10 @@ public class MicrometerDotNames {
             .createSimple("io.micrometer.prometheus.PrometheusMeterRegistry");
     public static final DotName PROMETHEUS_CONFIG = DotName
             .createSimple("io.micrometer.prometheus.PrometheusConfig");
+    public static final DotName STACKDRIVER_REGISTRY = DotName
+            .createSimple("io.micrometer.stackdriver.StackdriverMeterRegistry");
+    public static final DotName STACKDRIVER_CONFIG = DotName
+            .createSimple("package io.micrometer.stackdriver.StackdriverConfig");
 
     // public static final DotName METER_INTERFACE = DotName
     //         .createSimple(io.micrometer.core.instrument.Meter.class.getName());

--- a/deployment/src/main/java/dev/ebullient/micrometer/deployment/PrometheusConfig.java
+++ b/deployment/src/main/java/dev/ebullient/micrometer/deployment/PrometheusConfig.java
@@ -27,7 +27,7 @@ final class PrometheusConfig {
     /**
      * If the prometheus endpoint is enabled.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public boolean enabled;
 
     @Override

--- a/deployment/src/test/java/dev/ebullient/micrometer/deployment/StackdriverDisabledTestCase.java
+++ b/deployment/src/test/java/dev/ebullient/micrometer/deployment/StackdriverDisabledTestCase.java
@@ -1,0 +1,37 @@
+package dev.ebullient.micrometer.deployment;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Should not have any registered MeterRegistry objects when micrometer is disabled
+ */
+public class StackdriverDisabledTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.micrometer.export.stackdriver.enabled=false"),
+                            "application.properties"));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    public void testMeterRegistryPresent() {
+        // Micrometer is enabled, stackdriver is not.
+        Assertions.assertNotNull(registry, "A registry should be configured");
+        Assertions.assertFalse(registry instanceof StackdriverMeterRegistry, "Should not be StackdriverMeterRegistry");
+    }
+
+}

--- a/deployment/src/test/java/dev/ebullient/micrometer/deployment/StackdriverEnabledTestCase.java
+++ b/deployment/src/test/java/dev/ebullient/micrometer/deployment/StackdriverEnabledTestCase.java
@@ -1,0 +1,35 @@
+package dev.ebullient.micrometer.deployment;
+
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StackdriverEnabledTestCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(new StringAsset("quarkus.micrometer.export.stackdriver.enabled=true\n"
+                            + "quarkus.micrometer.export.stackdriver.project-id=myproject"),
+                            "application.properties"));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    public void testMeterRegistryPresent() {
+        // Stackdriver is enabled.
+        Assertions.assertNotNull(registry, "A registry should be configured");
+        Assertions.assertTrue(registry instanceof StackdriverMeterRegistry, "Should be StackdriverMeterRegistry");
+    }
+
+}

--- a/integration-tests/prometheus/src/test/resources/application.properties
+++ b/integration-tests/prometheus/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.micrometer.export.prometheus.enabled=true

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -59,6 +59,12 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-stackdriver</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/MicrometerRecorder.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/MicrometerRecorder.java
@@ -20,12 +20,7 @@ public class MicrometerRecorder {
     private static final Logger LOGGER = Logger.getLogger(MicrometerRecorder.class.getName());
 
     public Function<Router, Route> route(String name) {
-        return new Function<Router, Route>() {
-            @Override
-            public Route apply(Router router) {
-                return router.route(name);
-            }
-        };
+        return router -> router.route(name);
     }
 
     public void configureRegistry() {

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverConfig.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverConfig.java
@@ -1,0 +1,60 @@
+package dev.ebullient.micrometer.runtime;
+
+import static io.quarkus.runtime.annotations.ConfigPhase.BUILD_AND_RUN_TIME_FIXED;
+
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "micrometer.export.stackdriver", phase = BUILD_AND_RUN_TIME_FIXED)
+public class StackdriverConfig {
+
+    public static class StackdriverEnabled implements BooleanSupplier {
+        StackdriverConfig sConfig;
+
+        public boolean getAsBoolean() {
+            return sConfig.enabled;
+        }
+    }
+
+    /**
+     * If the stackdriver metrics are enabled.
+     *
+     * You will probably want to have this disabled on local environment.
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean enabled;
+
+    /**
+     * Project id where metrics will be pushed.
+     */
+    @ConfigItem
+    public Optional<String> projectId;
+
+    /**
+     * The interval at which metrics are sent to Stackdriver Monitoring. The default is 1 minute.
+     *
+     * Must be in ISO-8601 duration format PnDTnHnMn.nS e.g. PT30s, PT1m etc.
+     */
+    @ConfigItem(defaultValue = "PT1m")
+    public String step;
+
+    /**
+     * Stackdriver resource type. Default is global.
+     */
+    @ConfigItem(defaultValue = "global")
+    public String resourceType;
+
+    @Override
+    public String toString() {
+        return "StackdriverConfig{"
+                + ", enabled=" + enabled
+                + ", project=" + projectId
+                + ", step=" + step
+                + ", resourceType=" + resourceType
+                + '}';
+    }
+
+}

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverMeterRegistryProvider.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverMeterRegistryProvider.java
@@ -1,0 +1,62 @@
+package dev.ebullient.micrometer.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import io.quarkus.arc.DefaultBean;
+
+@Singleton
+public class StackdriverMeterRegistryProvider {
+
+    StackdriverConfig config;
+
+    @Produces
+    @Singleton
+    @DefaultBean
+    public io.micrometer.stackdriver.StackdriverConfig config() {
+        return new MicrometerStackdriverConfig(config);
+    }
+
+    @Produces
+    @Singleton
+    @DefaultBean
+    public StackdriverMeterRegistry registry(io.micrometer.stackdriver.StackdriverConfig config, Clock clock) {
+        return new StackdriverMeterRegistry(config, clock);
+    }
+
+    void setStackdriverConfig(StackdriverConfig config) {
+        this.config = config;
+    }
+
+    private static class MicrometerStackdriverConfig implements io.micrometer.stackdriver.StackdriverConfig {
+
+        private final String prefix;
+        private final Map<String, String> config;
+
+        private MicrometerStackdriverConfig(StackdriverConfig config) {
+            this.prefix = "stackdriver";
+            this.config = new HashMap<>();
+            this.config.put(prefix + ".step", config.step);
+            this.config.put(prefix + ".enabled", Boolean.toString(config.enabled));
+            this.config.put(prefix + ".projectId", config.projectId.orElse(null));
+            this.config.put(prefix + ".resourceType", config.resourceType);
+        }
+
+        @Override
+        public String get(String key) {
+            return config.get(key);
+        }
+
+        @Override
+        public String prefix() {
+            return prefix;
+        }
+
+    }
+
+}

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverRecorder.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/StackdriverRecorder.java
@@ -1,0 +1,16 @@
+package dev.ebullient.micrometer.runtime;
+
+import io.quarkus.arc.runtime.BeanContainerListener;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class StackdriverRecorder {
+
+    public BeanContainerListener setStackdriverConfig(StackdriverConfig config) {
+        return beanContainer -> {
+            StackdriverMeterRegistryProvider provider = beanContainer.instance(StackdriverMeterRegistryProvider.class);
+            provider.setStackdriverConfig(config);
+        };
+    }
+
+}


### PR DESCRIPTION
First thank you for writing this extension. 

Now, this commit adds Stackdriver support to your micrometer extension. 

Few notes:
1. I saw that Quarkus extensions usually have quarkus config in runtime module and not in deployment module. Since I need it there I put my StackdriverConfig in runtime module. I suggest that also other configs are moved in runtime module.

2. I currently did not add separate packages, but it might be great to have separate packages for Prometheus, Stackdriver and other systems. Or maybe every system should be a separate extension.

3. Micrometer StackdriverMeterRegistry requires project id to be set. But I did not find a way to make Quarkus build pass in case Stackdriver is disabled and projectId is not set. That is why I worked around this, and set @ConfigItem projectId as Optional<String>. And later in build process I check that in case Stackdriver is enabled, then build should fail (MicrometerProcessor line 203-205).  Do you maybe  now how can I achieve this without this workaround?

