### PR TITLE
jvm_info MeterBinder

### DIFF
--- a/integration-tests/mp-metrics/src/main/java/dev/ebullient/it/micrometer/mpmetrics/RenameMeterFilterProducer.java
+++ b/integration-tests/mp-metrics/src/main/java/dev/ebullient/it/micrometer/mpmetrics/RenameMeterFilterProducer.java
@@ -1,0 +1,32 @@
+package dev.ebullient.it.micrometer.mpmetrics;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+@Singleton
+public class RenameMeterFilterProducer {
+    static String targetMetric = PrimeResource.class.getName() + ".highestPrimeNumberSoFar";
+
+    @Produces
+    @Singleton
+    MeterFilter renameMeterFilter() {
+        return new MeterFilter() {
+            @Override
+            public Meter.Id map(Meter.Id id) {
+                if (id.getName().equals(targetMetric)) {
+                    List<Tag> tags = id.getTags().stream().filter(x -> !"scope".equals(x.getKey()))
+                            .collect(Collectors.toList());
+                    return id.withName("highestPrimeNumberSoFar").replaceTags(tags);
+                }
+                return id;
+            }
+        };
+    }
+}

--- a/integration-tests/mp-metrics/src/test/java/dev/ebullient/it/micrometer/mpmetrics/MPMetricsTest.java
+++ b/integration-tests/mp-metrics/src/test/java/dev/ebullient/it/micrometer/mpmetrics/MPMetricsTest.java
@@ -64,7 +64,7 @@ class MPMetricsTest {
                 .body(containsString(
                         "dev_ebullient_it_micrometer_mpmetrics_CountedInstance_countPrimes_total{scope=\"application\",} 2.0"))
                 .body(containsString(
-                        "dev_ebullient_it_micrometer_mpmetrics_PrimeResource_highestPrimeNumberSoFar{scope=\"application\",} 887.0"))
+                        "highestPrimeNumberSoFar 887.0"))
 
                 // the counter associated with a timed method should have been removed
                 .body(not(containsString("dev_ebullient_it_micrometer_mpmetrics_PrimeResource_checkPrime")));
@@ -92,7 +92,7 @@ class MPMetricsTest {
                 .body(containsString(
                         "dev_ebullient_it_micrometer_mpmetrics_CountedInstance_countPrimes_total{scope=\"application\",} 2.0"))
                 .body(containsString(
-                        "dev_ebullient_it_micrometer_mpmetrics_PrimeResource_highestPrimeNumberSoFar{scope=\"application\",} 887.0"))
+                        "highestPrimeNumberSoFar 887.0"))
                 .body(containsString(
                         "dev_ebullient_it_micrometer_mpmetrics_InjectedInstance_notPrime_total{scope=\"application\",}"));
     }

--- a/integration-tests/prometheus/src/test/java/dev/ebullient/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/prometheus/src/test/java/dev/ebullient/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -81,9 +81,11 @@ class PrometheusMetricsRegistryTest {
                 .statusCode(200)
 
                 // Prometheus body has ALL THE THINGS in no particular order
+                .body(containsString("jvm_info"))
 
                 .body(containsString("registry=\"prometheus\""))
                 .body(containsString("env=\"test\""))
+
                 .body(containsString("http_server_requests"))
 
                 .body(containsString("status=\"404\""))

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/MicrometerRecorder.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/MicrometerRecorder.java
@@ -17,6 +17,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
 
+import dev.ebullient.micrometer.runtime.binder.JvmInfoMetrics;
 import dev.ebullient.micrometer.runtime.binder.vertx.VertxMeterBinderAdapter;
 import dev.ebullient.micrometer.runtime.config.MicrometerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -95,6 +96,7 @@ public class MicrometerRecorder {
             new JvmHeapPressureMetrics().bindTo(Metrics.globalRegistry);
             new JvmMemoryMetrics().bindTo(Metrics.globalRegistry);
             new JvmThreadMetrics().bindTo(Metrics.globalRegistry);
+            new JvmInfoMetrics().bindTo(Metrics.globalRegistry);
         }
 
         // System

--- a/runtime/src/main/java/dev/ebullient/micrometer/runtime/binder/JvmInfoMetrics.java
+++ b/runtime/src/main/java/dev/ebullient/micrometer/runtime/binder/JvmInfoMetrics.java
@@ -1,0 +1,19 @@
+package dev.ebullient.micrometer.runtime.binder;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+public class JvmInfoMetrics implements MeterBinder {
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder("jvm.info", () -> 1L)
+                .description("JVM version info")
+                .tags("version", System.getProperty("java.runtime.version", "unknown"),
+                        "vendor", System.getProperty("java.vm.vendor", "unknown"),
+                        "runtime", System.getProperty("java.runtime.name", "unknown"))
+                .strongReference(true)
+                .register(registry);
+    }
+}

--- a/runtime/src/test/java/dev/ebullient/micrometer/runtime/binder/JvmMetricsInfoTest.java
+++ b/runtime/src/test/java/dev/ebullient/micrometer/runtime/binder/JvmMetricsInfoTest.java
@@ -1,0 +1,36 @@
+package dev.ebullient.micrometer.runtime.binder;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public class JvmMetricsInfoTest {
+    @Test
+    public void testJvmInfoMetrics() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        new JvmInfoMetrics().bindTo(registry);
+
+        Collection<Gauge> gauges = Search.in(registry).name("jvm.info").gauges();
+        Assertions.assertEquals(1, gauges.size(),
+                "Should find one jvm.info gauge");
+
+        Gauge jvmInfo = gauges.iterator().next();
+        Assertions.assertEquals(1L, jvmInfo.value(),
+                "jvm.info gauge should always return 1");
+
+        Meter.Id id = jvmInfo.getId();
+        Assertions.assertNotNull(id.getTag("version"),
+                "JVM version tag should be defined");
+        Assertions.assertNotNull(id.getTag("vendor"),
+                "JVM vendor tag should be defined");
+        Assertions.assertNotNull(id.getTag("runtime"),
+                "JVM runtime tag should be defined");
+    }
+}


### PR DESCRIPTION
Add a jvm_info gauge as the prom_client does.

Also submitted to micrometer-core:
https://github.com/micrometer-metrics/micrometer/pull/2221

Also added an additional test for MeterFilter registration behavior with regard to MP Metrics